### PR TITLE
Import pinttrs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           python3 -m venv fresh_env
           . fresh_env/bin/activate
           pip install dist/*.whl
-          fresh_env/bin/python -c "import pinttr; print(pinttr.__version__)"
+          fresh_env/bin/python -c "import pinttr; print(pinttrs.__version__)"
 
       - name: Upload to PyPI
         run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,20 +1,5 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 import pinttr
 import datetime
-
-# -- Path setup ----------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-
-# sys.path.insert(0, os.path.abspath("../src"))
 
 # -- Project information -------------------------------------------------------
 
@@ -48,6 +33,8 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "attrs": ("https://www.attrs.org/en/stable", None),
+    "pint": ("https://pint.readthedocs.io/en/stable", None),
 }
 
 # -- GitHub quicklinks with 'extlinks' -----------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-import pinttr
+import pinttrs
 import datetime
 
 # -- Project information -------------------------------------------------------
@@ -6,8 +6,8 @@ import datetime
 project = "Pinttrs"
 copyright = f"2021-{datetime.datetime.now().year}, Rayference"
 author = "Vincent Leroy"
-release = pinttr.__version__
-version = pinttr.__version__
+release = pinttrs.__version__
+version = pinttrs.__version__
 
 # -- General configuration -----------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,6 +102,8 @@ the ``attrs`` logo.
    :hidden:
 
    rst/api
+   rst/api_classic
+   rst/interface
    src/whats_new.md
 
 .. toctree::

--- a/docs/rst/api.rst
+++ b/docs/rst/api.rst
@@ -3,25 +3,25 @@
 API Reference
 =============
 
-.. currentmodule:: pinttr
+.. currentmodule:: pinttrs
 
 .. _api-main:
 
 Main interface
 --------------
 
-.. autofunction:: pinttr.ib
+.. autofunction:: pinttrs.field
 
 .. _api-dynamic:
 
 Dynamic unit management
 -----------------------
 
-.. autoclass:: pinttr.UnitGenerator
+.. autoclass:: pinttrs.UnitGenerator
    :members:
    :special-members: __call__
 
-.. autoclass:: pinttr.UnitContext
+.. autoclass:: pinttrs.UnitContext
    :members:
    :special-members: __getitem__, __setitem__
 
@@ -30,52 +30,43 @@ Dynamic unit management
 Default unit registry
 ---------------------
 
-.. autofunction:: pinttr.get_unit_registry
-.. autofunction:: pinttr.set_unit_registry
+.. autofunction:: pinttrs.get_unit_registry
+.. autofunction:: pinttrs.set_unit_registry
 
 .. _api-dict_interpretation:
 
 Dictionary interpretation
 -------------------------
 
-.. autofunction:: pinttr.interpret_units
+.. autofunction:: pinttrs.interpret_units
 
 .. _api-converters:
 
-Converters [``pinttr.converters``]
-----------------------------------
+Converters [``pinttrs.converters``]
+-----------------------------------
 
-.. autofunction:: pinttr.converters.to_units
+.. autofunction:: pinttrs.converters.to_units
 
 .. _api-validators:
 
-Validators [``pinttr.validators``]
-----------------------------------
+Validators [``pinttrs.validators``]
+-----------------------------------
 
-.. autofunction:: pinttr.validators.has_compatible_units
+.. autofunction:: pinttrs.validators.has_compatible_units
 
 .. _api-utilities:
 
-Utilities [``pinttr.util``]
----------------------------
+Utilities [``pinttrs.util``]
+----------------------------
 
-.. autofunction:: pinttr.util.always_iterable
-.. autofunction:: pinttr.converters.ensure_units
-.. autofunction:: pinttr.util.units_compatible
+.. autofunction:: pinttrs.util.always_iterable
+.. autofunction:: pinttrs.converters.ensure_units
+.. autofunction:: pinttrs.util.units_compatible
 
 .. _api-exceptions:
 
-Exceptions [``pinttr.exceptions``]
-----------------------------------
+Exceptions [``pinttrs.exceptions``]
+-----------------------------------
 
-.. autoexception:: pinttr.exceptions.UnitsError
+.. autoexception:: pinttrs.exceptions.UnitsError
    :show-inheritance:
-
-Next-generation APIs
---------------------
-
-Pinttrs provides APIs matching ``attrs``
-`next-generation APIs <https://www.attrs.org/en/stable/api.html#next-generation-apis>`_
-for syntactic homogeneity.
-
-.. autofunction:: pinttr.field

--- a/docs/rst/api_classic.rst
+++ b/docs/rst/api_classic.rst
@@ -1,0 +1,72 @@
+.. _api_classic:
+
+API Reference (classic)
+=======================
+
+.. currentmodule:: pinttr
+
+.. _api_classic-main:
+
+Main interface
+--------------
+
+.. autofunction:: pinttr.ib
+
+.. _api_classic-dynamic:
+
+Dynamic unit management
+-----------------------
+
+.. autoclass:: pinttr.UnitGenerator
+   :members:
+   :special-members: __call__
+
+.. autoclass:: pinttr.UnitContext
+   :members:
+   :special-members: __getitem__, __setitem__
+
+.. _api_classic-unit_registry:
+
+Default unit registry
+---------------------
+
+.. autofunction:: pinttr.get_unit_registry
+.. autofunction:: pinttr.set_unit_registry
+
+.. _api_classic-dict_interpretation:
+
+Dictionary interpretation
+-------------------------
+
+.. autofunction:: pinttr.interpret_units
+
+.. _api_classic-converters:
+
+Converters [``pinttr.converters``]
+----------------------------------
+
+.. autofunction:: pinttr.converters.to_units
+
+.. _api_classic-validators:
+
+Validators [``pinttr.validators``]
+----------------------------------
+
+.. autofunction:: pinttr.validators.has_compatible_units
+
+.. _api_classic-utilities:
+
+Utilities [``pinttr.util``]
+---------------------------
+
+.. autofunction:: pinttr.util.always_iterable
+.. autofunction:: pinttr.converters.ensure_units
+.. autofunction:: pinttr.util.units_compatible
+
+.. _api_classic-exceptions:
+
+Exceptions [``pinttr.exceptions``]
+----------------------------------
+
+.. autoexception:: pinttr.exceptions.UnitsError
+   :show-inheritance:

--- a/docs/rst/compatible.rst
+++ b/docs/rst/compatible.rst
@@ -47,7 +47,7 @@ neither declare as incompatible quantities which should not be mixed such as
 radiance (W/m²/sr) and irradiance (W/m²).
 
 For this reason, Pinttrs implements a stricter unit compatibility checker
-function :func:`~pinttr.util.units_compatible` which will declare as
+function :func:`~pinttrs.util.units_compatible` which will declare as
 incompatible dimensionless quantities with inconvertible units. For instance,
 while this will return ``True``
 
@@ -62,8 +62,8 @@ the following will not
 
 .. doctest::
 
-   >>> import pinttr
-   >>> pinttr.util.units_compatible(u1, u2)
+   >>> import pinttrs
+   >>> pinttrs.util.units_compatible(u1, u2)
    False
 
 While this does not prevent from adding radiances and irradiances, it, at least,

--- a/docs/rst/interface.rst
+++ b/docs/rst/interface.rst
@@ -1,0 +1,42 @@
+
+.. _usage-interface:
+
+About the Pinttrs interface
+===========================
+
+.. admonition:: TL;DR
+   :class: note
+
+   * As of Pinttrs v23.2.0, using the modern APIs is recommended. The classic APIs are, however, still available.
+   * As of Pinttrs v23.2.0, using `import attrs` is recommended. The classic `import attr` is still supported.
+
+Pinttrs initially mimicked the ``attrs`` import and interface policies so
+that using it would feel natural to ``attrs`` users. Therefore, the code was
+located in a ``pinttr`` package, and the main interface was :func:`pinttr.ib`.
+Typically, a field definition would look like this:
+
+.. doctest::
+
+   >>> import attr, pinttr
+   >>> ureg = pinttr.get_unit_registry()
+   >>> @attr.s
+   ... class MyClass:
+   ...     field = pinttr.ib(units=ureg.m)
+   >>> MyClass(1.0)
+   MyClass(field=1.0 m)
+
+As mentioned in the `documentation <https://www.attrs.org/en/latest/names.html>`_,
+the ``attrs`` interface then evolved. Pinttrs followed the movement in order
+to provide similar expressiveness. Consequently, we introduced :class:`pinttrs.field` and the ``pinttrs`` package:
+
+.. doctest::
+
+   >>> import attrs, pinttrs
+   >>> @attrs.define
+   ... class MyClass:
+   ...     field = pinttrs.field(units=ureg.m)
+   >>> MyClass(1.0)
+   MyClass(field=1.0 m)
+
+This interface is recommended, but the classic one is still available and
+supported.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Development Status :: 3 - Alpha"
 ]
 dependencies = [
-    "attrs>=21",
+    "attrs>=21.3",
     "pint>=0.16",
 ]
 

--- a/src/pinttrs/__init__.py
+++ b/src/pinttrs/__init__.py
@@ -1,0 +1,14 @@
+from pinttr import (
+    UnitContext,
+    UnitGenerator,
+    __version__,
+    attrib,
+    converters,
+    exceptions,
+    field,
+    get_unit_registry,
+    interpret_units,
+    set_unit_registry,
+    util,
+    validators,
+)

--- a/src/pinttrs/__init__.pyi
+++ b/src/pinttrs/__init__.pyi
@@ -1,0 +1,12 @@
+from pinttr import UnitContext as UnitContext
+from pinttr import UnitGenerator as UnitGenerator
+from pinttr import __version__ as __version__
+from pinttr import attrib as attrib
+from pinttr import converters as converters
+from pinttr import exceptions as exceptions
+from pinttr import field as field
+from pinttr import get_unit_registry as get_unit_registry
+from pinttr import interpret_units as interpret_units
+from pinttr import set_unit_registry as set_unit_registry
+from pinttr import util as util
+from pinttr import validators as validators


### PR DESCRIPTION
This PR adds the `pinttrs` namespace and finally aligns with the decisions made by the `attrs` development team regarding their interface.

The typical way to define a Pinttrs field is now:
```python
>>> import attrs, pinttrs
>>> @attrs.define
... class MyClass:
...     field = pinttrs.field(units=ureg.m)
>>> MyClass(1.0)
MyClass(field=1.0 m)
```